### PR TITLE
Update APIRequestHandler.swift

### DIFF
--- a/SwiftCairo-App/Networking/RequestHandlers/APIRequestHandler.swift
+++ b/SwiftCairo-App/Networking/RequestHandlers/APIRequestHandler.swift
@@ -54,7 +54,12 @@ extension APIRequestHandler {
             for (key, value) in parameters {
                 mul.append("\(value)".data(using: String.Encoding.utf8)!, withName: key as String)
             }
-        }, with: request).responseData { results in
+            
+        }, with: request).uploadProgress(closure: { prog in
+            print(prog)
+            progress?(prog)
+        })
+        .responseData { results in
             self.handleResponse(results, completion: then)
         }.responseString { string in
             debugPrint(string.value as Any)


### PR DESCRIPTION
Before `progress: ((Progress) -> Void)?` closure was never called during upload multipart. To fix this issue I used `uploadProgress` closure and whatever the values will be received we will pass to the `progress?(prog)`